### PR TITLE
PHP strict standards warning and fix

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -536,7 +536,7 @@ class assign_submission_pdf extends assign_submission_plugin {
      * @param stdClass $submission The submission
      * @return array - return an array of files indexed by filename
      */
-    public function get_files(stdClass $submission) {
+    public function get_files(stdClass $submission, stdClass $user) {
         $result = array();
         $fs = get_file_storage();
 


### PR DESCRIPTION
```
Strict standards: Declaration of assign_submission_pdf::get_files() should be compatible with that of assign_plugin::get_files() in /var/www/moodle/mod/assign/submission/pdf/locallib.php on line 788
```

This very minor edit prevents the error appearing simply by replicating the expected passed objects.
